### PR TITLE
Fix crash when no Calendar app found on date click

### DIFF
--- a/app/src/main/java/eu/ottop/yamlauncher/MainActivity.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/MainActivity.kt
@@ -2,6 +2,7 @@ package eu.ottop.yamlauncher
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
@@ -395,14 +396,19 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                 if (sharedPreferenceManager.isGestureEnabled("date") && dateApp.first != null && dateApp.second != null) {
                     launcherApps.startMainActivity(dateApp.first!!.componentName,  launcherApps.profiles[dateApp.second!!], null, null)
                 } else {
-                    startActivity(
-                        Intent(
-                            Intent.makeMainSelectorActivity(
-                                Intent.ACTION_MAIN,
-                                Intent.CATEGORY_APP_CALENDAR
+                    try {
+                        startActivity(
+                            Intent(
+                                Intent.makeMainSelectorActivity(
+                                    Intent.ACTION_MAIN,
+                                    Intent.CATEGORY_APP_CALENDAR
+                                )
                             )
                         )
-                    )
+                    }
+                    catch(_: ActivityNotFoundException) {
+                        Toast.makeText(this, getString(R.string.no_calendar_app), Toast.LENGTH_SHORT).show()
+                    }
                 }
             }
         }

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -13,6 +13,7 @@
     <string name="open_app_menu">Avaa sovellusvalikko</string>
 
     <!--App Menu-->
+    <string name="no_calendar_app">Kalenteri-sovellusta ei löytynyt</string>
     <string name="select_an_app">Valitse sovellus</string>
 
     <string name="search">Haku…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
 
     <string name="open_app_menu">Open App Menu</string>
 
+    <string name="no_calendar_app">No Calendar app found</string>
+
     <!--App Menu-->
     <string name="select_an_app">Select an app</string>
 


### PR DESCRIPTION
In some custom OS Calendar app may not be available by default.