### PR TITLE
Don't allow empty name in app rename

### DIFF
--- a/app/src/main/java/eu/ottop/yamlauncher/AppActionMenu.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/AppActionMenu.kt
@@ -15,6 +15,7 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.widget.AppCompatButton
 import androidx.core.view.ViewCompat
 import androidx.lifecycle.lifecycleScope
@@ -157,6 +158,10 @@ class AppActionMenu(private val activity: MainActivity, private val binding: Act
 
             // Once the new name is confirmed, close the keyboard, save the new app name and update the apps on screen
             if (actionId == EditorInfo.IME_ACTION_DONE) {
+                if (editText.text.isNullOrBlank()) {
+                    Toast.makeText(activity, activity.getString(R.string.empty_rename), Toast.LENGTH_SHORT).show()
+                    return@setOnEditorActionListener true
+                }
                 val imm =
                     activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
                 imm.hideSoftInputFromWindow(editText.windowToken, 0)

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -33,6 +33,7 @@
     <string name="launch_error">Sovelluksen avaaminen epäonnistui</string>
 
     <!--Action Menu Items-->
+    <string name="empty_rename">Tyhjää sovelluksen nimeä ei voi määrittää</string>
     <string name="info">Tiedot</string>
     <string name="uninstall">Poista</string>
     <string name="rename">Nimeä</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
 
     <string name="launch_error">Cannot launch app</string>
 
+    <string name="empty_rename">Cannot set empty app name</string>
+
     <!--Action Menu Items-->
     <string name="info">Info</string>
     <string name="uninstall">Uninstall</string>


### PR DESCRIPTION
In status quo we are allowing user to rename an app with an empty string, should we allow it?