### PR TITLE
add simple fuzzy search

### DIFF
--- a/app/src/main/java/eu/ottop/yamlauncher/MainActivity.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/MainActivity.kt
@@ -955,6 +955,14 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
             updateMenu(updatedApps)
         } else {
             isJobActive = false
+
+            val fuzzyPattern = if(sharedPreferenceManager.isFuzzySearchEnabled()) {
+                stringUtils.getFuzzyPattern(cleanQuery)
+            }
+            else {
+                null
+            }
+
             updatedApps.forEach {
                 val cleanItemText = stringUtils.cleanString(sharedPreferenceManager.getAppName(
                     it.first.applicationInfo.packageName,
@@ -962,7 +970,10 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                     packageManager.getApplicationLabel(it.first.applicationInfo)
                 ).toString())
                 if (cleanItemText != null) {
-                    if (cleanItemText.contains(cleanQuery, ignoreCase = true)) {
+                    if (
+                        (fuzzyPattern != null && cleanItemText.contains(fuzzyPattern)) ||
+                        (cleanItemText.contains(cleanQuery, ignoreCase = true))
+                    ) {
                         newFilteredApps.add(it)
                     }
                 }

--- a/app/src/main/java/eu/ottop/yamlauncher/settings/GestureAppsFragment.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/GestureAppsFragment.kt
@@ -114,6 +114,12 @@ class GestureAppsFragment(private val direction: String) : Fragment(),
         if (cleanQuery.isNullOrEmpty()) {
             newFilteredApps.addAll(updatedApps)
         } else {
+            val fuzzyPattern = if(sharedPreferenceManager.isFuzzySearchEnabled()) {
+                stringUtils.getFuzzyPattern(cleanQuery)
+            }
+            else {
+                null
+            }
             updatedApps.forEach {
                 val cleanItemText = stringUtils.cleanString(sharedPreferenceManager.getAppName(
                     it.first.applicationInfo.packageName,
@@ -121,7 +127,10 @@ class GestureAppsFragment(private val direction: String) : Fragment(),
                     requireContext().packageManager.getApplicationLabel(it.first.applicationInfo)
                 ).toString())
                 if (cleanItemText != null) {
-                    if (cleanItemText.contains(cleanQuery, ignoreCase = true)) {
+                    if (
+                        (fuzzyPattern != null && cleanItemText.contains(fuzzyPattern)) ||
+                        (cleanItemText.contains(cleanQuery, ignoreCase = true))
+                    ) {
                         newFilteredApps.add(it)
                     }
                 }

--- a/app/src/main/java/eu/ottop/yamlauncher/settings/HiddenAppsFragment.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/HiddenAppsFragment.kt
@@ -114,6 +114,12 @@ class HiddenAppsFragment : Fragment(), HiddenAppsAdapter.OnItemClickListener, Ti
         if (cleanQuery.isNullOrEmpty()) {
             newFilteredApps.addAll(updatedApps)
         } else {
+            val fuzzyPattern = if(sharedPreferenceManager.isFuzzySearchEnabled()) {
+                stringUtils.getFuzzyPattern(cleanQuery)
+            }
+            else {
+                null
+            }
             updatedApps.forEach {
                 val cleanItemText = stringUtils.cleanString(sharedPreferenceManager.getAppName(
                     it.first.applicationInfo.packageName,
@@ -121,7 +127,10 @@ class HiddenAppsFragment : Fragment(), HiddenAppsAdapter.OnItemClickListener, Ti
                     requireContext().packageManager.getApplicationLabel(it.first.applicationInfo)
                 ).toString())
                 if (cleanItemText != null) {
-                    if (cleanItemText.contains(cleanQuery, ignoreCase = true)) {
+                    if (
+                        (fuzzyPattern != null && cleanItemText.contains(fuzzyPattern)) ||
+                        (cleanItemText.contains(cleanQuery, ignoreCase = true))
+                    ) {
                         newFilteredApps.add(it)
                     }
                 }

--- a/app/src/main/java/eu/ottop/yamlauncher/settings/SharedPreferenceManager.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/SharedPreferenceManager.kt
@@ -211,6 +211,10 @@ class SharedPreferenceManager (private val context: Context) {
         return preferences.getString("searchSize", "medium")
     }
 
+    fun isFuzzySearchEnabled(): Boolean {
+        return preferences.getBoolean("fuzzySearchEnabled", false)
+    }
+
     fun getAppSpacing(): Int? {
         return preferences.getString("appSpacing", "20")?.toInt()
     }

--- a/app/src/main/java/eu/ottop/yamlauncher/utils/StringUtils.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/utils/StringUtils.kt
@@ -23,4 +23,19 @@ class StringUtils {
         view.movementMethod = LinkMovementMethod.getInstance()
     }
 
+    /** Create a Regex pattern for simple Fuzzy search
+     *
+     * Example:
+     * 'cl' will create 'c.*l' which matches 'Clock', 'Calendar'
+     * 'msg' will create 'm.*s.*g' which matches 'Messages'
+     * 'cmr' will create 'c.*m.*r' which matches 'Camera'
+     */
+    fun getFuzzyPattern(query: String): Regex {
+        val pattern = query
+            .flatMap { char -> listOf(char.toString(), ".*") }
+            // remove the last unnecessary .* since the char itself is sufficient
+            .dropLast(1)
+            .joinToString(separator = "")
+        return Regex(pattern, RegexOption.IGNORE_CASE)
+    }
 }

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -124,6 +124,7 @@
     <string name="enable_search">Näytä Hakupalkki</string>
     <string name="search_alignment">Hakupalkin Sijainti</string>
     <string name="search_size">Hakupalkin Koko</string>
+    <string name="enable_fuzzy_search">Ota sumea haku käyttöön</string>
     <string name="automatically_open_keyboard">Avaa Näppäimistö Automaattisesti</string>
     <string name="automatic_app_opening">Avaa Hakutulos Automaattisesti</string>
     <string name="auto_launch_summary">Avaa sovellus automaattisesti kun se on viimeinen hakutulos</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,7 @@
     <string name="enable_search">Enable Search</string>
     <string name="search_alignment">Search Alignment</string>
     <string name="search_size">Search Size</string>
+    <string name="enable_fuzzy_search">Enable Fuzzy Search</string>
     <string name="automatically_open_keyboard">Automatically Open Keyboard</string>
     <string name="automatic_app_opening">Automatic App Opening</string>
     <string name="auto_launch_summary">Automatically launch an app when it\'s the last search result</string>

--- a/app/src/main/res/xml/app_menu_preferences.xml
+++ b/app/src/main/res/xml/app_menu_preferences.xml
@@ -73,6 +73,13 @@
         <SwitchPreference
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            app:dependency="searchEnabled"
+            android:defaultValue="false"
+            android:title="@string/enable_fuzzy_search"
+            app:key="fuzzySearchEnabled" />
+        <SwitchPreference
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:defaultValue="false"
             android:title="@string/automatically_open_keyboard"
             app:dependency="searchEnabled"


### PR DESCRIPTION
This change enables to fuzzy search app names.
Existing search matches the search sequence exactly with the app name.
This pull request will allow searching app names with letters in order instead of the exact sequence.

This will allow to search like:
'cmr' => Camera
'clk' or 'cck' => Clock
'fx' => Firefox

But this will also change existing behavior:
status quo: 'cl' => Clock
fuzzy search: 'cl' => Clock, Calendar

**Note:** This will not work on Contact search, since we are filtering contacts with Cursor