### PR TITLE
Show Launch activity label instead of app name

### DIFF
--- a/app/src/main/java/eu/ottop/yamlauncher/AppActionMenu.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/AppActionMenu.kt
@@ -33,10 +33,9 @@ class AppActionMenu(private val activity: MainActivity, private val binding: Act
         textView: TextView,
         editLayout: LinearLayout,
         actionMenu: View,
-        appInfo: ApplicationInfo,
+        appActivity: LauncherActivityInfo,
         userHandle: UserHandle,
-        workProfile: Int,
-        appActivity: LauncherActivityInfo?
+        workProfile: Int
     ){
 
 
@@ -52,32 +51,32 @@ class AppActionMenu(private val activity: MainActivity, private val binding: Act
         }
 
         ViewCompat.addAccessibilityAction(textView, activity.getString(R.string.accessibility_uninstall)) { _, _ ->
-            uninstallApp(appInfo, userHandle)
+            uninstallApp(appActivity.applicationInfo, userHandle)
             true
         }
 
         actionMenu.findViewById<TextView>(R.id.uninstall).setOnClickListener {
-            uninstallApp(appInfo, userHandle)
+            uninstallApp(appActivity.applicationInfo, userHandle)
             animations.fadeViewOut(actionMenu)
             textView.visibility = View.VISIBLE
         }
 
         ViewCompat.addAccessibilityAction(textView, activity.getString(R.string.accessibility_rename)) { _, _ ->
-            renameApp(textView, editLayout, actionMenu, appActivity, appInfo, userHandle, workProfile)
+            renameApp(textView, editLayout, actionMenu, appActivity, userHandle, workProfile)
             true
         }
 
         actionMenu.findViewById<TextView>(R.id.rename).setOnClickListener {
-            renameApp(textView, editLayout, actionMenu, appActivity, appInfo, userHandle, workProfile)
+            renameApp(textView, editLayout, actionMenu, appActivity, userHandle, workProfile)
         }
 
         ViewCompat.addAccessibilityAction(textView, activity.getString(R.string.accessibility_hide)) { _, _ ->
-            hideApp(editLayout, textView, actionMenu, appInfo, workProfile)
+            hideApp(editLayout, textView, actionMenu, appActivity, workProfile)
             true
         }
 
         actionMenu.findViewById<TextView>(R.id.hide).setOnClickListener {
-            hideApp(editLayout, textView, actionMenu, appInfo, workProfile)
+            hideApp(editLayout, textView, actionMenu, appActivity, workProfile)
         }
 
         actionMenu.findViewById<TextView>(R.id.close).setOnClickListener {
@@ -109,7 +108,7 @@ class AppActionMenu(private val activity: MainActivity, private val binding: Act
         activity.returnAllowed = false
     }
 
-    private fun renameApp(textView: TextView, editLayout: LinearLayout, actionMenu: View, appActivity: LauncherActivityInfo?, appInfo: ApplicationInfo, userHandle: UserHandle, workProfile: Int) {
+    private fun renameApp(textView: TextView, editLayout: LinearLayout, actionMenu: View, appActivity: LauncherActivityInfo, userHandle: UserHandle, workProfile: Int) {
         activity.disableAppMenuScroll()
         textView.visibility = View.INVISIBLE
         animations.fadeViewIn(editLayout)
@@ -117,7 +116,7 @@ class AppActionMenu(private val activity: MainActivity, private val binding: Act
         val editText = editLayout.findViewById<EditText>(R.id.appNameEdit)
         val resetButton = editLayout.findViewById<AppCompatButton>(R.id.reset)
 
-        val app = Triple(appActivity!!, userHandle, workProfile)
+        val app = Triple(appActivity, userHandle, workProfile)
 
         val searchEnabled = sharedPreferenceManager.isSearchEnabled()
 
@@ -166,7 +165,7 @@ class AppActionMenu(private val activity: MainActivity, private val binding: Act
                     activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
                 imm.hideSoftInputFromWindow(editText.windowToken, 0)
                 sharedPreferenceManager.setAppName(
-                    appInfo.packageName,
+                    app.first.componentName.flattenToString(),
                     workProfile,
                     editText.text.toString()
                 )
@@ -187,7 +186,7 @@ class AppActionMenu(private val activity: MainActivity, private val binding: Act
                 activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
             imm.hideSoftInputFromWindow(editLayout.windowToken, 0)
             sharedPreferenceManager.resetAppName(
-                app.first.applicationInfo.packageName,
+                app.first.componentName.flattenToString(),
                 app.third
             )
 
@@ -197,12 +196,12 @@ class AppActionMenu(private val activity: MainActivity, private val binding: Act
         }
     }
 
-    private fun hideApp(editLayout: LinearLayout, textView: TextView, actionMenu: View, appInfo: ApplicationInfo, workProfile: Int) {
+    private fun hideApp(editLayout: LinearLayout, textView: TextView, actionMenu: View, appActivity: LauncherActivityInfo, workProfile: Int) {
         editLayout.visibility = View.GONE
         textView.visibility = View.GONE
         actionMenu.visibility = View.GONE
         activity.lifecycleScope.launch {
-            sharedPreferenceManager.setAppHidden(appInfo.packageName, workProfile, true)
+            sharedPreferenceManager.setAppHidden(appActivity.componentName.flattenToString(), workProfile, true)
             activity.refreshAppMenu()
         }
     }

--- a/app/src/main/java/eu/ottop/yamlauncher/AppMenuAdapter.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/AppMenuAdapter.kt
@@ -131,25 +131,23 @@ class AppMenuAdapter(
         holder.textView.setTextColor(sharedPreferenceManager.getTextColor())
 
         // Update the application information (allows updating apps to work)
-        val appInfo = appUtils.getAppInfo(
+        val isAppInstalled = appUtils.getAppInfo(
             app.first.applicationInfo.packageName,
             app.third
-        )
+        ) != null
 
         // Set app name on the menu. If the app has been uninstalled, replace it with "Removing" until the app menu updates.
-        val appLabel: CharSequence = appInfo?.let { activity.packageManager.getApplicationLabel(it) } ?: activity.getString(R.string.removing)
-
-        if (appInfo != null) {
+        if (isAppInstalled) {
             holder.textView.text = sharedPreferenceManager.getAppName(
-                appInfo.packageName,
+                app.first.componentName.flattenToString(),
                 app.third,
-                appLabel
+                app.first.label
             )
 
             holder.editText.setText(holder.textView.text)
 
             // Remove the uninstall icon for system apps
-            if (appInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0) {
+            if (app.first.applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0) {
                 holder.actionMenuLayout.findViewById<TextView>(R.id.uninstall).visibility =
                     View.GONE
             } else {
@@ -157,22 +155,20 @@ class AppMenuAdapter(
                     View.VISIBLE
             }
         }
-        else {holder.textView.text = appLabel}
+        else {
+            holder.textView.text = activity.getString(R.string.removing)
+        }
 
         holder.textView.visibility = View.VISIBLE
 
-        if (appInfo != null) {
-
-            val appActivity = launcherApps.getActivityList(appInfo.packageName, app.second).firstOrNull()
-
+        if (isAppInstalled) {
             appActionMenu.setActionListeners(
                 holder.textView,
                 holder.editView,
                 holder.actionMenuLayout,
-                appInfo,
+                app.first,
                 app.second,
                 app.third,
-                appActivity
             )
         }
         ViewCompat.addAccessibilityAction(holder.textView, activity.getString(R.string.close_app_menu)) { _, _ ->

--- a/app/src/main/java/eu/ottop/yamlauncher/settings/GestureAppsAdapter.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/GestureAppsAdapter.kt
@@ -67,12 +67,10 @@ class GestureAppsAdapter(
         uiUtils.setItemSpacing(holder.textView)
 
         // Does not need to be specially updated since it's in a separate activity and thus reloads when opened again
-        val appInfo = app.first.activityInfo.applicationInfo
-
         holder.textView.text = sharedPreferenceManager.getAppName(
-            app.first.applicationInfo.packageName,
+            app.first.componentName.flattenToString(),
             app.third,
-            context.packageManager.getApplicationLabel(appInfo)
+            app.first.label
         )
 
         holder.textView.visibility = View.VISIBLE

--- a/app/src/main/java/eu/ottop/yamlauncher/settings/GestureAppsFragment.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/GestureAppsFragment.kt
@@ -122,9 +122,9 @@ class GestureAppsFragment(private val direction: String) : Fragment(),
             }
             updatedApps.forEach {
                 val cleanItemText = stringUtils.cleanString(sharedPreferenceManager.getAppName(
-                    it.first.applicationInfo.packageName,
+                    it.first.componentName.flattenToString(),
                     it.third,
-                    requireContext().packageManager.getApplicationLabel(it.first.applicationInfo)
+                    it.first.label
                 ).toString())
                 if (cleanItemText != null) {
                     if (
@@ -159,7 +159,7 @@ class GestureAppsFragment(private val direction: String) : Fragment(),
 
     private fun performConfirmedAction(appInfo: LauncherActivityInfo, appName: String, profile: Int) {
         sharedPreferenceManager.setGestures(
-            direction, "$appName§splitter§${appInfo.applicationInfo.packageName}§splitter§$profile"
+            direction, "$appName§splitter§${appInfo.componentName.flattenToString()}§splitter§$profile"
         )
         requireActivity().supportFragmentManager.popBackStack()
     }
@@ -167,9 +167,9 @@ class GestureAppsFragment(private val direction: String) : Fragment(),
 
     override fun onItemClick(appInfo: LauncherActivityInfo, profile: Int) {
         showConfirmationDialog(appInfo, sharedPreferenceManager.getAppName(
-            appInfo.applicationInfo.packageName,
+            appInfo.componentName.flattenToString(),
             profile,
-            requireContext().packageManager.getApplicationLabel(appInfo.applicationInfo)
+            appInfo.label
         ).toString(), profile)
     }
 

--- a/app/src/main/java/eu/ottop/yamlauncher/settings/HiddenAppsAdapter.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/HiddenAppsAdapter.kt
@@ -68,11 +68,10 @@ class HiddenAppsAdapter(
         uiUtils.setItemSpacing(holder.textView)
 
         // Separate activity from Main so does not need special update
-        val appInfo = app.first.activityInfo.applicationInfo
         holder.textView.text = sharedPreferenceManager.getAppName(
-            app.first.applicationInfo.packageName,
+            app.first.componentName.flattenToString(),
             app.third,
-            context.packageManager.getApplicationLabel(appInfo)
+            app.first.label
         )
 
         holder.textView.visibility = View.VISIBLE

--- a/app/src/main/java/eu/ottop/yamlauncher/settings/HiddenAppsFragment.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/HiddenAppsFragment.kt
@@ -122,9 +122,9 @@ class HiddenAppsFragment : Fragment(), HiddenAppsAdapter.OnItemClickListener, Ti
             }
             updatedApps.forEach {
                 val cleanItemText = stringUtils.cleanString(sharedPreferenceManager.getAppName(
-                    it.first.applicationInfo.packageName,
+                    it.first.componentName.flattenToString(),
                     it.third,
-                    requireContext().packageManager.getApplicationLabel(it.first.applicationInfo)
+                    it.first.label
                 ).toString())
                 if (cleanItemText != null) {
                     if (
@@ -158,15 +158,15 @@ class HiddenAppsFragment : Fragment(), HiddenAppsAdapter.OnItemClickListener, Ti
     }
 
     private suspend fun performConfirmedAction(appInfo: LauncherActivityInfo, profile: Int) {
-        sharedPreferenceManager.setAppVisible(appInfo.applicationInfo.packageName, profile)
+        sharedPreferenceManager.setAppVisible(appInfo.componentName.flattenToString(), profile)
         adapter?.updateApps(appUtils.getHiddenApps())
     }
 
     override fun onItemClick(appInfo: LauncherActivityInfo, profile: Int) {
         showConfirmationDialog(appInfo, sharedPreferenceManager.getAppName(
-            appInfo.applicationInfo.packageName,
+            appInfo.componentName.flattenToString(),
             profile,
-            requireContext().packageManager.getApplicationLabel(appInfo.applicationInfo)
+            appInfo.label
         ).toString(), profile)
     }
 

--- a/app/src/main/java/eu/ottop/yamlauncher/settings/SharedPreferenceManager.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/SharedPreferenceManager.kt
@@ -88,9 +88,9 @@ class SharedPreferenceManager (private val context: Context) {
         return preferences.getString("dateSize", "medium")
     }
 
-    fun setShortcut(index: Int, text: CharSequence, packageName: String, profile: Int, isContact: Boolean = false) {
+    fun setShortcut(index: Int, text: CharSequence, componentName: String, profile: Int, isContact: Boolean = false) {
         val editor = preferences.edit()
-        editor.putString("shortcut${index}", "$packageName§splitter§$profile§splitter§${text}§splitter§${isContact}")
+        editor.putString("shortcut${index}", "$componentName§splitter§$profile§splitter§${text}§splitter§${isContact}")
         editor.apply()
     }
 
@@ -245,36 +245,36 @@ class SharedPreferenceManager (private val context: Context) {
     }
 
     // Hidden Apps
-    fun setAppHidden(packageName: String, profile: Int, hidden: Boolean) {
+    fun setAppHidden(componentName: String, profile: Int, hidden: Boolean) {
         val editor = preferences.edit()
-        editor.putBoolean("hidden$packageName-$profile", hidden)
+        editor.putBoolean("hidden$componentName-$profile", hidden)
         editor.apply()
     }
 
-    fun isAppHidden(packageName: String, profile: Int): Boolean {
-        return preferences.getBoolean("hidden$packageName-$profile", false) // Default to false (visible)
+    fun isAppHidden(componentName: String, profile: Int): Boolean {
+        return preferences.getBoolean("hidden$componentName-$profile", false) // Default to false (visible)
     }
 
-    fun setAppVisible(packageName: String, profile: Int) {
+    fun setAppVisible(componentName: String, profile: Int) {
         val editor = preferences.edit()
-        editor.remove("hidden$packageName-$profile")
+        editor.remove("hidden$componentName-$profile")
         editor.apply()
     }
 
     //Renaming apps
-    fun setAppName(packageName: String, profile: Int, newName: String) {
+    fun setAppName(componentName: String, profile: Int, newName: String) {
         val editor = preferences.edit()
-        editor.putString("name$packageName-$profile", newName)
+        editor.putString("name$componentName-$profile", newName)
         editor.apply()
     }
 
-    fun getAppName(packageName: String, profile: Int, appName: CharSequence): CharSequence? {
-        return preferences.getString("name$packageName-$profile", appName.toString())
+    fun getAppName(componentName: String, profile: Int, appName: CharSequence): CharSequence? {
+        return preferences.getString("name$componentName-$profile", appName.toString())
     }
 
-    fun resetAppName(packageName: String, profile: Int) {
+    fun resetAppName(componentName: String, profile: Int) {
         val editor = preferences.edit()
-        editor.remove("name$packageName-$profile")
+        editor.remove("name$componentName-$profile")
         editor.apply()
     }
 

--- a/app/src/main/java/eu/ottop/yamlauncher/utils/AppUtils.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/utils/AppUtils.kt
@@ -1,5 +1,6 @@
 package eu.ottop.yamlauncher.utils
 
+import android.content.ComponentName
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.LauncherActivityInfo
@@ -22,7 +23,7 @@ class AppUtils(private val context: Context, private val launcherApps: LauncherA
             for (i in launcherApps.profiles.indices) { // Check apps on both, normal and work profiles
                 launcherApps.getActivityList(null, launcherApps.profiles[i]).forEach { app ->
                     if (!sharedPreferenceManager.isAppHidden( // Only include the app if it isn't set as hidden
-                            app.applicationInfo.packageName,
+                            app.componentName.flattenToString(),
                             i
                         ) && app.applicationInfo.packageName != context.applicationInfo.packageName // Hide the launcher itself
                     ) {
@@ -34,9 +35,9 @@ class AppUtils(private val context: Context, private val launcherApps: LauncherA
             // Sort apps by name
             sortedApps = allApps.sortedBy {
                 sharedPreferenceManager.getAppName(
-                    it.first.applicationInfo.packageName,
+                    it.first.componentName.flattenToString(),
                     it.third,
-                    context.packageManager.getApplicationLabel(it.first.applicationInfo)
+                    it.first.label
                 ).toString().lowercase()
             }
         }
@@ -51,7 +52,7 @@ class AppUtils(private val context: Context, private val launcherApps: LauncherA
         withContext(Dispatchers.Default) {
         for (i in launcherApps.profiles.indices) {
             launcherApps.getActivityList(null, launcherApps.profiles[i]).forEach { app ->
-                if (sharedPreferenceManager.isAppHidden(app.applicationInfo.packageName, i)) {
+                if (sharedPreferenceManager.isAppHidden(app.componentName.flattenToString(), i)) {
                     allApps.add(Triple(app, launcherApps.profiles[i], i))
                 }
             }
@@ -60,9 +61,9 @@ class AppUtils(private val context: Context, private val launcherApps: LauncherA
         //Sort apps by name
         sortedApps = allApps.sortedBy {
         sharedPreferenceManager.getAppName(
-            it.first.applicationInfo.packageName,
+            it.first.componentName.flattenToString(),
             it.third,
-            context.packageManager.getApplicationLabel(it.first.applicationInfo)
+            it.first.label
         ).toString().lowercase()
         }
         }
@@ -80,12 +81,7 @@ class AppUtils(private val context: Context, private val launcherApps: LauncherA
         }
     }
 
-    fun launchApp(packageName: String, userHandle: UserHandle) {
-        val mainActivity = launcherApps.getActivityList(packageName, userHandle).firstOrNull()
-        if (mainActivity != null) {
-            launcherApps.startMainActivity(mainActivity.componentName,  userHandle, null, null)
-        } else {
-            Toast.makeText(context, context.getString(R.string.launch_error), Toast.LENGTH_SHORT).show()
-        }
+    fun launchApp(componentName: ComponentName, userHandle: UserHandle) {
+        launcherApps.startMainActivity(componentName,  userHandle, null, null)
     }
 }


### PR DESCRIPTION
This fixes issue #24 to show and launch apps with multiple Main Launcher activities correctly

* Show Main Launcher activity with its own label instead of App name
* Use ComponentName instead of package name for Hidden apps, Shortcut, App rename, Gesture, etc.

@ottop Please check the changes once, I have checked the changes it working correctly AFAICT