### PR TITLE
The Kotlin JVM toolchain and target are explicitly set to version 17.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,11 +43,16 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
     buildFeatures {
         viewBinding = true
+    }
+}
+
+kotlin {
+    jvmToolchain(17)
+
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 


### PR DESCRIPTION
The Kotlin JVM toolchain and target are explicitly set to version 17.