### PR TITLE
fix: prioritize exact matches in search

### DIFF
--- a/app/src/main/java/eu/ottop/yamlauncher/MainActivity.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/MainActivity.kt
@@ -1162,7 +1162,20 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                 )
             }
 
-            return filteredList
+            // Sort to prioritize exact matches
+            val sortedList = filteredList.sortedWith(compareBy { appItem ->
+                val cleanItemText = stringUtils.cleanString(
+                    sharedPreferenceManager.getAppName(
+                        appItem.first.componentName.flattenToString(),
+                        appItem.third,
+                        appItem.first.label
+                    ).toString()
+                )
+                // Exact match gets 0 (first), non-exact gets 1 (later)
+                if (cleanItemText.equals(cleanQuery, ignoreCase = true)) 0 else 1
+            })
+
+            return sortedList
         }
     }
 


### PR DESCRIPTION
Issue: Searching "X" doesn't bring it at top.

Future: Maybe there could be a better "relevance" search, but this is minimal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Search results now prioritize exact matches (case-insensitive), so typing an exact app name shows that app at the top. Improves relevance without affecting the order of other results.

<sup>Written for commit 39888e04a9cce0e841381962f944ed95e8733cf1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

