### PR TITLE
Manual location search: debounce + safer Open-Meteo parsing

### DIFF
--- a/app/src/main/java/eu/ottop/yamlauncher/settings/LocationListAdapter.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/LocationListAdapter.kt
@@ -33,6 +33,7 @@ class LocationListAdapter(
 
             listItem.setOnClickListener {
                 val position = bindingAdapterPosition
+                if (position == RecyclerView.NO_POSITION) return@setOnClickListener
                 val name = locations[position]["name"]
                 val latitude = locations[position]["latitude"]
                 val longitude = locations[position]["longitude"]
@@ -69,7 +70,6 @@ class LocationListAdapter(
 
     @SuppressLint("NotifyDataSetChanged")
     fun updateLocations(newApps: MutableList<Map<String, String>>) {
-        locations.clear()
         locations = newApps
         notifyDataSetChanged()
     }


### PR DESCRIPTION
## Why
Manual location search can spam the geocoding API and can fail/crash on empty results.

## What changed
- Debounce input and ignore stale results; clear list for queries < 2 chars
- Harden Open-Meteo geocoding parsing and handle HTTP errors/no-results
- Add connect/read timeouts and use device locale for the `language` param
- Guard RecyclerView clicks against `NO_POSITION`

## Testing
- `./gradlew test`
