### PR TITLE
Settings backup/restore: schema v2 + StringSet support

### DIFF
--- a/app/src/main/java/eu/ottop/yamlauncher/settings/SettingsActivity.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/SettingsActivity.kt
@@ -200,7 +200,10 @@ class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferen
                 while (keys.hasNext()){
                     val key = keys.next()
                     val entry = data.getJSONObject(key)
-                    val type = entry.getString("type")
+                    val type = entry.optString("type", "")
+                    if (type.isEmpty()) {
+                        continue
+                    }
 
                     when (type) {
                         "String" -> editor.putString(key, entry.getString("value"))
@@ -218,9 +221,10 @@ class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferen
                                 editor.putStringSet(key, set)
                             }
                         }
+                        else -> {}
                     }
                 }
-                editor.putBoolean("isRestored", true)
+                editor.putBoolean(TRANSIENT_PREF_KEY_RESTORED, true)
 
                 editor.apply()
 


### PR DESCRIPTION
## Why
Backups should round-trip reliably and restores should not leave stale keys behind.

## What changed
- Add `schema_version` + `created_at` metadata; read/write JSON as UTF-8
- Include `StringSet` preferences (schema v2)
- Clear existing prefs before restore; skip transient `isRestored` in backups

## Testing
- `./gradlew test`
