### PR TITLE
Potential fix for code scanning alert no. 7: Insecure local authentication

### DIFF
--- a/app/src/main/java/eu/ottop/yamlauncher/utils/BiometricUtils.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/utils/BiometricUtils.kt
@@ -6,10 +6,19 @@ import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import eu.ottop.yamlauncher.R
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
 
 class BiometricUtils(private val activity: FragmentActivity) {
     private lateinit var callbackSettings: CallbackSettings
     private val logger = Logger.getInstance(activity)
+
+    // Alias for the key used to protect access to biometric-protected settings
+    private val settingsKeyAlias = "YamLauncherSettingsKey"
 
     interface CallbackSettings {
         fun onAuthenticationSucceeded()
@@ -17,13 +26,114 @@ class BiometricUtils(private val activity: FragmentActivity) {
         fun onAuthenticationError(errorCode: Int, errorMessage: CharSequence?)
     }
 
+    private fun generateSecretKeyIfNeeded() {
+        try {
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            val existingKey = keyStore.getKey(settingsKeyAlias, null)
+            if (existingKey != null) {
+                return
+            }
+            val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+                settingsKeyAlias,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_CBC)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_PKCS7)
+                .setUserAuthenticationRequired(true)
+                .setInvalidatedByBiometricEnrollment(true)
+                .build()
+            val keyGenerator = KeyGenerator.getInstance(
+                KeyProperties.KEY_ALGORITHM_AES,
+                "AndroidKeyStore"
+            )
+            keyGenerator.init(keyGenParameterSpec)
+            keyGenerator.generateKey()
+            logger.i("BiometricUtils", "Generated new keystore key for biometric settings")
+        } catch (e: Exception) {
+            logger.e("BiometricUtils", "Failed to generate keystore key: ${e.message}")
+        }
+    }
+
+    private fun getSecretKey(): SecretKey? {
+        return try {
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            keyStore.load(null)
+            keyStore.getKey(settingsKeyAlias, null) as? SecretKey
+        } catch (e: Exception) {
+            logger.e("BiometricUtils", "Failed to obtain keystore key: ${e.message}")
+            null
+        }
+    }
+
+    private fun getCipher(): Cipher? {
+        return try {
+            Cipher.getInstance(
+                "${KeyProperties.KEY_ALGORITHM_AES}/" +
+                    "${KeyProperties.BLOCK_MODE_CBC}/" +
+                    KeyProperties.ENCRYPTION_PADDING_PKCS7
+            )
+        } catch (e: Exception) {
+            logger.e("BiometricUtils", "Failed to get Cipher instance: ${e.message}")
+            null
+        }
+    }
+
     fun startBiometricSettingsAuth(callbackApp: CallbackSettings) {
         this.callbackSettings = callbackApp
+
+        // Ensure a keystore-backed key exists for protecting settings access
+        generateSecretKeyIfNeeded()
+        val secretKey = getSecretKey()
+        val cipher = getCipher()
+
+        if (secretKey == null || cipher == null) {
+            logger.e("BiometricUtils", "Unable to start biometric auth due to missing crypto components")
+            callbackSettings.onAuthenticationError(
+                BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL,
+                "Biometric cryptographic components not available"
+            )
+            return
+        }
+
+        try {
+            // Initialize cipher; we simply perform an encryption in onAuthenticationSucceeded
+            cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+        } catch (e: Exception) {
+            logger.e("BiometricUtils", "Failed to initialize cipher: ${e.message}")
+            callbackSettings.onAuthenticationError(
+                BiometricPrompt.ERROR_UNABLE_TO_PROCESS,
+                "Unable to initialize biometric cipher"
+            )
+            return
+        }
 
         val authenticationCallback = object : BiometricPrompt.AuthenticationCallback() {
             override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
                 logger.i("BiometricUtils", "Biometric authentication succeeded")
-                callbackSettings.onAuthenticationSucceeded()
+                try {
+                    val cryptoObject = result.cryptoObject
+                    val authCipher = cryptoObject?.cipher
+                    if (authCipher == null) {
+                        logger.e("BiometricUtils", "No cipher available from biometric result")
+                        callbackSettings.onAuthenticationError(
+                            BiometricPrompt.ERROR_UNABLE_TO_PROCESS,
+                            "Biometric cipher not available"
+                        )
+                        return
+                    }
+                    // Perform a cryptographic operation that depends on the keystore key.
+                    // We encrypt a fixed value; if this fails, authentication is treated as failed.
+                    val testData = "settings_auth".toByteArray(Charsets.UTF_8)
+                    authCipher.doFinal(testData)
+                    callbackSettings.onAuthenticationSucceeded()
+                } catch (e: Exception) {
+                    logger.e("BiometricUtils", "Cryptographic operation failed after biometric auth: ${e.message}")
+                    callbackSettings.onAuthenticationError(
+                        BiometricPrompt.ERROR_UNABLE_TO_PROCESS,
+                        "Biometric cryptographic operation failed"
+                    )
+                }
             }
 
             override fun onAuthenticationFailed() {
@@ -57,7 +167,10 @@ class BiometricUtils(private val activity: FragmentActivity) {
 
         if (canAuthenticate == BiometricManager.BIOMETRIC_SUCCESS) {
             logger.i("BiometricUtils", "Starting biometric authentication")
-            biometricPrompt.authenticate(promptInfo)
+            biometricPrompt.authenticate(
+                BiometricPrompt.CryptoObject(cipher),
+                promptInfo
+            )
         } else {
             logger.w("BiometricUtils", "Biometric authentication not available: $canAuthenticate")
         }


### PR DESCRIPTION
Potential fix for [https://github.com/ThomasNowProductions/YAM-Launcher/security/code-scanning/7](https://github.com/ThomasNowProductions/YAM-Launcher/security/code-scanning/7)

In general, to fix this problem, the biometric authentication must be tied to a keystore-backed key and a cryptographic operation. That means: generate a secret key in the Android Keystore with `setUserAuthenticationRequired(true)`, obtain a `Cipher` initialized with that key for encryption or decryption, pass it as a `BiometricPrompt.CryptoObject` to `authenticate`, and then in `onAuthenticationSucceeded` use the `result.cryptoObject` to perform a cryptographic operation that is required for the sensitive part of the app (for example, decrypting a blob of configuration or a token).

For this specific file, we can keep the existing external behavior (a simple callback interface) but internally enforce secure local auth:

- Add private helper methods to `BiometricUtils`:
  - `generateSecretKey()` to create a `SecretKey` in the Android Keystore (if not already present), using `KeyGenParameterSpec` with `setUserAuthenticationRequired(true)` and `setInvalidatedByBiometricEnrollment(true)`.
  - `getSecretKey()` to load the key from `AndroidKeyStore`.
  - `getCipher()` to get a properly configured AES/CBC/PKCS7 `Cipher`.
  - Optionally a small helper to create or validate some encrypted data so that the cipher is actually used.
- In `startBiometricSettingsAuth`, before building the prompt, ensure the key exists (`generateSecretKey()`).
- Initialize a `Cipher` with the secret key. For a simple pattern that does not require us to persist data elsewhere, we can initialize the cipher in `ENCRYPT_MODE` and perform a trivial encryption in `onAuthenticationSucceeded`. This ties the biometric success to the possession and usability of the keystore-backed key without changing any outward behavior.
- Change the call from `biometricPrompt.authenticate(promptInfo)` to `biometricPrompt.authenticate(BiometricPrompt.CryptoObject(cipher), promptInfo)`.
- Update `onAuthenticationSucceeded` to obtain the `Cipher` via `result.cryptoObject?.cipher` and perform a `doFinal` on some fixed data, catching any exceptions and treating them as authentication errors.

We will:
- Add necessary imports (`KeyStore`, `KeyGenerator`, `KeyGenParameterSpec`, `KeyProperties`, `Cipher`, `SecretKey`).
- Add a constant key alias and helper methods inside `BiometricUtils`.
- Modify the authentication setup to include the `CryptoObject` and to use the `Cipher` in `onAuthenticationSucceeded`, but still call the existing `callbackSettings` methods so functionality remains the same from callers’ perspective.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure local authentication by binding biometric unlock to an Android Keystore-backed key and a required crypto operation. This addresses code scanning alert #7 for insecure local auth.

- **Bug Fixes**
  - Generate an AES key in Android Keystore with user authentication required and invalidation on biometric changes.
  - Initialize a Cipher and pass it as BiometricPrompt.CryptoObject; on success, encrypt fixed data via result.cryptoObject.cipher to verify.
  - Preserve existing CallbackSettings API while adding logging and graceful errors when crypto components are unavailable.

<sup>Written for commit fd631ea86f9608caeac2fcd72ecfbacc8a5f3bb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

