### PR TITLE
Fix launcher crash when tapping shortcut to uninstalled app

### DIFF
--- a/app/src/main/java/eu/ottop/yamlauncher/MainActivity.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/MainActivity.kt
@@ -466,11 +466,17 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
     private fun setShortcutListeners(textView: TextView, savedView: List<String>?) {
         textView.setOnClickListener {
             if (savedView != null && canLaunchShortcut) {
+                val userHandle = launcherApps.profiles[savedView[1].toInt()]
                 val componentName = if (savedView[0].contains("/")) {
                     val (packageName, className) = savedView[0].split("/")
-                    ComponentName(packageName, className)
+                    val cn = ComponentName(packageName, className)
+                    if (launcherApps.getActivityList(packageName, userHandle).none { it.componentName == cn }) {
+                        logger.w("MainActivity", "Failed to launch shortcut: ${savedView[0]} not found")
+                        Toast.makeText(this, this.getString(R.string.launch_error), Toast.LENGTH_SHORT).show()
+                        return@setOnClickListener
+                    }
+                    cn
                 } else {
-                    val userHandle = launcherApps.profiles[savedView[1].toInt()]
                     val mainActivity = launcherApps.getActivityList(savedView[0], userHandle).firstOrNull()
                     if (mainActivity != null) {
                         mainActivity.componentName
@@ -480,7 +486,7 @@ class MainActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferenceCh
                         return@setOnClickListener
                     }
                 }
-                appUtils.launchApp(componentName, launcherApps.profiles[savedView[1].toInt()])
+                appUtils.launchApp(componentName, userHandle)
             }
         }
     }


### PR DESCRIPTION
The "/" component name branch in setShortcutListeners created a
ComponentName directly without verifying the app was still installed,
causing startMainActivity to throw and crash the launcher. Now checks
getActivityList first and shows a toast on failure, matching the
existing guard in the else branch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a launcher crash when tapping a shortcut to an uninstalled app. We now validate the target component before launching and show a toast if it’s missing.

- **Bug Fixes**
  - In `setShortcutListeners`, verify the component exists via getActivityList when the shortcut string contains “/”; if not found, log and show `launch_error` toast instead of crashing.
  - Reuse the computed `userHandle` and pass it to `launchApp` to avoid duplicate lookups.

<sup>Written for commit b01c2d2f09ca512bfd03e1713d7cd08b93ffe626. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

