### PR TITLE
Fix TalkBack traversal order in settings screen

### DIFF
--- a/app/src/main/java/eu/ottop/yamlauncher/settings/SettingsActivity.kt
+++ b/app/src/main/java/eu/ottop/yamlauncher/settings/SettingsActivity.kt
@@ -59,6 +59,7 @@ class SettingsActivity : AppCompatActivity(), SharedPreferences.OnSharedPreferen
         uiUtils.setBackground(window)
         preferences.registerOnSharedPreferenceChangeListener(this)
 
+        setSupportActionBar(binding.settingsToolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.title = getString(R.string.settings_title)
         supportActionBar?.setDisplayShowTitleEnabled(true)

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -8,10 +8,17 @@
     android:orientation="vertical"
     tools:context=".settings.SettingsActivity">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/settingsToolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/settingsLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:paddingTop="5dp">
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,7 +14,7 @@
         <item name="colorAccent">#FF80CBC4</item>
     </style>
 
-    <style name="SettingsTheme" parent="Theme.AppCompat">
+    <style name="SettingsTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="android:windowBackground">@color/settings_bg</item>
         <item name="android:windowShowWallpaper">true</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>


### PR DESCRIPTION
The action bar was in the Window decor view (outside the layout
hierarchy), so TalkBack reached the navigate-up button and title
last. Replaced the decor-view action bar with a MaterialToolbar
in the layout XML so it is traversed first, and switched
SettingsTheme to NoActionBar to suppress the duplicate system bar.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TalkBack traversal in the Settings screen by moving the app bar into the layout with a `MaterialToolbar`, so the Up button and title are read first. Also removes the duplicate system action bar.

- **Bug Fixes**
  - Replaced decor-view action bar with `MaterialToolbar` in `activity_settings.xml` to appear first in accessibility order.
  - Set the toolbar as the `supportActionBar` in `SettingsActivity` and enabled Up navigation.
  - Switched `SettingsTheme` to `Theme.AppCompat.NoActionBar` to prevent a second system bar.

<sup>Written for commit 28802636b2beac68a31a611ab9153e21ac9ff62a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

